### PR TITLE
Update vimrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,8 @@ call plug#end()
 " Map F2 to auto check code betty style or pycodestyle or shellcheck
 function! CheckCode()
     let filetype = &filetype
-    if filetype ==# 'c' || filetype ==# 'h'
+    let filename = expand('%:t')
+    if filetype ==# 'c' || filename =~# '\.h$'
         execute '!betty %'
     elseif filetype ==# 'python'
         execute '!pycodestyle %'


### PR DESCRIPTION
there was no built-in filetype key for header files so betty was not working for header file (.h). with this update you can now use it.

changes:
- use the extension of the file to check if it ends with `.h`